### PR TITLE
Fix vercel deployment build failure

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
   images: {
     domains: ['lh3.googleusercontent.com'],
   },

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
     "typescript": "^5"
+  },
+  "engines": {
+    "node": "18.x"
   }
 }

--- a/src/components/providers/AuthProvider.tsx
+++ b/src/components/providers/AuthProvider.tsx
@@ -11,7 +11,7 @@ import {
   signInWithPopup
 } from 'firebase/auth';
 import { doc, setDoc, getDoc } from 'firebase/firestore';
-import { auth, db } from '@/lib/firebase';
+import { getClientAuth, getClientDb } from '@/lib/firebase';
 
 interface AuthContextType {
   user: User | null;
@@ -29,6 +29,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    const auth = getClientAuth();
+    const db = getClientDb();
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
         // Check if user document exists, if not create it
@@ -56,6 +58,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signIn = async (email: string, password: string) => {
     try {
+      const auth = getClientAuth();
       await signInWithEmailAndPassword(auth, email, password);
     } catch (error) {
       throw error;
@@ -64,6 +67,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signUp = async (email: string, password: string) => {
     try {
+      const auth = getClientAuth();
       const result = await createUserWithEmailAndPassword(auth, email, password);
       // User document will be created in the useEffect above
     } catch (error) {
@@ -73,6 +77,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const signOutUser = async () => {
     try {
+      const auth = getClientAuth();
       await signOut(auth);
     } catch (error) {
       throw error;
@@ -82,6 +87,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signInWithGoogle = async () => {
     try {
       const provider = new GoogleAuthProvider();
+      const auth = getClientAuth();
       await signInWithPopup(auth, provider);
     } catch (error) {
       throw error;

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,23 +1,65 @@
-import { initializeApp } from 'firebase/app';
-import { getAuth } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
-import { getStorage } from 'firebase/storage';
+// Ensure this file is only used on the client. Avoids running during SSR/prerender.
+// We export async getters so initialization is lazy and safe in client components/effects.
 
-const firebaseConfig = {
-  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-  storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-};
+import { initializeApp, getApps, getApp } from 'firebase/app';
+import { getAuth, Auth } from 'firebase/auth';
+import { getFirestore, Firestore } from 'firebase/firestore';
+import { getStorage, FirebaseStorage } from 'firebase/storage';
 
-// Initialize Firebase
-const app = initializeApp(firebaseConfig);
+let cachedAuth: Auth | null = null;
+let cachedDb: Firestore | null = null;
+let cachedStorage: FirebaseStorage | null = null;
 
-// Initialize Firebase services
-export const auth = getAuth(app);
-export const db = getFirestore(app);
-export const storage = getStorage(app);
+function getFirebaseConfig() {
+  return {
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  } as const;
+}
 
-export default app;
+function ensureClientApp() {
+  const config = getFirebaseConfig();
+  const hasAllKeys = Object.values(config).every(Boolean);
+  if (!hasAllKeys) {
+    throw new Error('Firebase config is missing. Set NEXT_PUBLIC_FIREBASE_* env vars.');
+  }
+  const app = getApps().length ? getApp() : initializeApp(config);
+  return app;
+}
+
+export function getClientAuth(): Auth {
+  if (typeof window === 'undefined') {
+    throw new Error('getClientAuth must be called on the client');
+  }
+  if (!cachedAuth) {
+    const app = ensureClientApp();
+    cachedAuth = getAuth(app);
+  }
+  return cachedAuth;
+}
+
+export function getClientDb(): Firestore {
+  if (typeof window === 'undefined') {
+    throw new Error('getClientDb must be called on the client');
+  }
+  if (!cachedDb) {
+    const app = ensureClientApp();
+    cachedDb = getFirestore(app);
+  }
+  return cachedDb;
+}
+
+export function getClientStorage(): FirebaseStorage {
+  if (typeof window === 'undefined') {
+    throw new Error('getClientStorage must be called on the client');
+  }
+  if (!cachedStorage) {
+    const app = ensureClientApp();
+    cachedStorage = getStorage(app);
+  }
+  return cachedStorage;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "lib": ["dom", "dom.iterable", "es6"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -24,5 +24,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "functions", "functions/**/*"]
 }


### PR DESCRIPTION
Fix Vercel build failure by updating Next.js/TypeScript config and making Firebase initialization client-only.

The build was failing due to an invalid Next.js experimental flag, TypeScript attempting to type-check the Firebase functions workspace, an outdated TypeScript target causing runtime errors, and Firebase initialization occurring during server-side prerendering. These changes address all identified causes of the build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6d332b0-dc90-4e67-9c8f-177831a1526e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b6d332b0-dc90-4e67-9c8f-177831a1526e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

